### PR TITLE
Optics protocols

### DIFF
--- a/Focus.xcodeproj/project.pbxproj
+++ b/Focus.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		11D137051B544D0000E76EBA /* Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D137041B544D0000E76EBA /* Protocols.swift */; };
+		11D137061B544D0000E76EBA /* Protocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11D137041B544D0000E76EBA /* Protocols.swift */; };
 		824B45F91B460AC1009AAF49 /* Focus.h in Headers */ = {isa = PBXBuildFile; fileRef = 824B45F81B460AC1009AAF49 /* Focus.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		824B46001B460AC1009AAF49 /* Focus.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 824B45F51B460AC1009AAF49 /* Focus.framework */; };
 		824B461E1B460AFA009AAF49 /* Focus.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 824B46141B460AFA009AAF49 /* Focus.framework */; };
@@ -118,6 +120,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		11D137041B544D0000E76EBA /* Protocols.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Protocols.swift; sourceTree = "<group>"; usesTabs = 1; };
 		824B45F51B460AC1009AAF49 /* Focus.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Focus.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		824B45F81B460AC1009AAF49 /* Focus.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = Focus.h; path = Focus/Focus.h; sourceTree = "<group>"; };
 		824B45FA1B460AC1009AAF49 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -125,22 +128,22 @@
 		824B46061B460AC1009AAF49 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		824B46141B460AFA009AAF49 /* Focus.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Focus.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		824B461D1B460AFA009AAF49 /* Focus-iOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Focus-iOSTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		824B462B1B460B25009AAF49 /* Iso.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Iso.swift; sourceTree = "<group>"; };
-		824B462C1B460B25009AAF49 /* IxCont.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IxCont.swift; sourceTree = "<group>"; };
-		824B462D1B460B25009AAF49 /* IxMultiStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IxMultiStore.swift; sourceTree = "<group>"; };
-		824B462E1B460B25009AAF49 /* IxState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IxState.swift; sourceTree = "<group>"; };
-		824B462F1B460B25009AAF49 /* IxStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IxStore.swift; sourceTree = "<group>"; };
+		824B462B1B460B25009AAF49 /* Iso.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Iso.swift; sourceTree = "<group>"; usesTabs = 1; };
+		824B462C1B460B25009AAF49 /* IxCont.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IxCont.swift; sourceTree = "<group>"; usesTabs = 1; };
+		824B462D1B460B25009AAF49 /* IxMultiStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IxMultiStore.swift; sourceTree = "<group>"; usesTabs = 1; };
+		824B462E1B460B25009AAF49 /* IxState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IxState.swift; sourceTree = "<group>"; usesTabs = 1; };
+		824B462F1B460B25009AAF49 /* IxStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IxStore.swift; sourceTree = "<group>"; usesTabs = 1; };
 		824B46301B460B25009AAF49 /* Lens.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Lens.swift; sourceTree = "<group>"; usesTabs = 1; };
-		824B46311B460B25009AAF49 /* Prism.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Prism.swift; sourceTree = "<group>"; };
-		824B46411B460BE2009AAF49 /* ArrayZipper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArrayZipper.swift; sourceTree = "<group>"; };
-		824B46471B460C1E009AAF49 /* LensOperators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LensOperators.swift; sourceTree = "<group>"; };
-		824B464A1B460E69009AAF49 /* PartyExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PartyExample.swift; sourceTree = "<group>"; };
-		824B464B1B460E69009AAF49 /* UserExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserExample.swift; sourceTree = "<group>"; };
+		824B46311B460B25009AAF49 /* Prism.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Prism.swift; sourceTree = "<group>"; usesTabs = 1; };
+		824B46411B460BE2009AAF49 /* ArrayZipper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArrayZipper.swift; sourceTree = "<group>"; usesTabs = 1; };
+		824B46471B460C1E009AAF49 /* LensOperators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LensOperators.swift; sourceTree = "<group>"; usesTabs = 1; };
+		824B464A1B460E69009AAF49 /* PartyExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PartyExample.swift; sourceTree = "<group>"; usesTabs = 1; };
+		824B464B1B460E69009AAF49 /* UserExample.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserExample.swift; sourceTree = "<group>"; usesTabs = 1; };
 		82DD8EC71B48D1CA00B66551 /* SwiftCheck.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SwiftCheck.xcodeproj; path = Carthage/Checkouts/SwiftCheck/SwiftCheck.xcodeproj; sourceTree = SOURCE_ROOT; };
-		82DD8EDE1B48D2EB00B66551 /* LensSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LensSpec.swift; sourceTree = "<group>"; };
-		82DD8EE31B48DDB200B66551 /* PrismSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrismSpec.swift; sourceTree = "<group>"; };
-		82DD8EE61B48DF8700B66551 /* IsoSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IsoSpec.swift; sourceTree = "<group>"; };
-		82DD8EFC1B4CE0E600B66551 /* Operators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Operators.swift; path = Carthage/Checkouts/Operadics/Operators.swift; sourceTree = SOURCE_ROOT; };
+		82DD8EDE1B48D2EB00B66551 /* LensSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LensSpec.swift; sourceTree = "<group>"; usesTabs = 1; };
+		82DD8EE31B48DDB200B66551 /* PrismSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PrismSpec.swift; sourceTree = "<group>"; usesTabs = 1; };
+		82DD8EE61B48DF8700B66551 /* IsoSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IsoSpec.swift; sourceTree = "<group>"; usesTabs = 1; };
+		82DD8EFC1B4CE0E600B66551 /* Operators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Operators.swift; path = Carthage/Checkouts/Operadics/Operators.swift; sourceTree = SOURCE_ROOT; usesTabs = 1; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -208,6 +211,7 @@
 				82DD8EFC1B4CE0E600B66551 /* Operators.swift */,
 				824B46301B460B25009AAF49 /* Lens.swift */,
 				824B462B1B460B25009AAF49 /* Iso.swift */,
+				11D137041B544D0000E76EBA /* Protocols.swift */,
 				824B46311B460B25009AAF49 /* Prism.swift */,
 				824B462C1B460B25009AAF49 /* IxCont.swift */,
 				824B462D1B460B25009AAF49 /* IxMultiStore.swift */,
@@ -484,6 +488,7 @@
 				824B46361B460B25009AAF49 /* IxMultiStore.swift in Sources */,
 				82DD8EFD1B4CE0E600B66551 /* Operators.swift in Sources */,
 				824B463E1B460B25009AAF49 /* Prism.swift in Sources */,
+				11D137051B544D0000E76EBA /* Protocols.swift in Sources */,
 				824B46341B460B25009AAF49 /* IxCont.swift in Sources */,
 				824B46381B460B25009AAF49 /* IxState.swift in Sources */,
 				824B46321B460B25009AAF49 /* Iso.swift in Sources */,
@@ -513,6 +518,7 @@
 				824B46371B460B25009AAF49 /* IxMultiStore.swift in Sources */,
 				82DD8EFE1B4CE0E600B66551 /* Operators.swift in Sources */,
 				824B463F1B460B25009AAF49 /* Prism.swift in Sources */,
+				11D137061B544D0000E76EBA /* Protocols.swift in Sources */,
 				824B46351B460B25009AAF49 /* IxCont.swift in Sources */,
 				824B46391B460B25009AAF49 /* IxState.swift in Sources */,
 				824B46331B460B25009AAF49 /* Iso.swift in Sources */,

--- a/Focus/Iso.swift
+++ b/Focus/Iso.swift
@@ -41,6 +41,15 @@ public protocol IsoType : OpticFamilyType, LensType, PrismType {
 	func inject(_ : AltTarget) -> AltSource
 }
 
+extension Iso {
+	public init<Other : IsoType where
+		S == Other.Source, A == Other.Target, T == Other.AltSource, B == Other.AltTarget>
+		(_ other : Other)
+	{
+		self.init(get: other.get, inject: other.inject)
+	}
+}
+
 /// The identity isomorphism.
 public func identity<S, T>() -> Iso<S, T, S, T> {
 	return Iso(get: identity, inject: identity)

--- a/Focus/Iso.swift
+++ b/Focus/Iso.swift
@@ -13,7 +13,7 @@
 /// - parameter A: The source of the Iso heading right
 /// - parameter B: The target of the Iso heading left
 public struct Iso<S, T, A, B> : IsoType {
-    typealias Source = S
+	typealias Source = S
 	typealias Target = A
 	typealias AltSource = T
 	typealias AltTarget = B
@@ -27,16 +27,16 @@ public struct Iso<S, T, A, B> : IsoType {
 		_inject = g
 	}
 
-	public func get(v: S) -> A {
+	public func get(v : S) -> A {
 		return _get(v)
 	}
 
-	public func inject(x: B) -> T {
+	public func inject(x : B) -> T {
 		return _inject(x)
 	}
 }
 
-public protocol IsoType : OpticFamilyType {
+public protocol IsoType : OpticFamilyType, LensType {
 	func get(_ : Source) -> Target
 	func inject(_ : AltTarget) -> AltSource
 }
@@ -47,6 +47,12 @@ public func identity<S, T>() -> Iso<S, T, S, T> {
 }
 
 extension IsoType {
+	public func run(v : Source) -> IxStore<Target, AltTarget, AltSource> {
+		return IxStore<Target, AltTarget, AltSource>(get(v)) { x in
+			return self.inject(x)
+		}
+	}
+
 	/// Runs a value of type `S` along both parts of the Iso.
 	public func modify(v : Source, _ f : Target -> AltTarget) -> AltSource {
 		return inject(f(get(v)))
@@ -56,7 +62,7 @@ extension IsoType {
 	public func compose<Other : IsoType where
 		Self.Target == Other.Source,
 		Self.AltTarget == Other.AltSource>
-		(other : Other) -> Iso<Self.Source, Self.AltSource, Other.Target, Other.AltTarget>
+		(other : Other) -> Iso<Source, AltSource, Other.Target, Other.AltTarget>
 	{
 		return Iso(get: other.get • self.get, inject: self.inject • other.inject)
 	}

--- a/Focus/Iso.swift
+++ b/Focus/Iso.swift
@@ -36,7 +36,7 @@ public struct Iso<S, T, A, B> : IsoType {
 	}
 }
 
-public protocol IsoType : OpticFamilyType, LensType {
+public protocol IsoType : OpticFamilyType, LensType, PrismType {
 	func get(_ : Source) -> Target
 	func inject(_ : AltTarget) -> AltSource
 }
@@ -51,6 +51,10 @@ extension IsoType {
 		return IxStore<Target, AltTarget, AltSource>(get(v)) { x in
 			return self.inject(x)
 		}
+	}
+
+	public func tryGet(v : Source) -> Target? {
+		return get(v)
 	}
 
 	/// Runs a value of type `S` along both parts of the Iso.

--- a/Focus/Iso.swift
+++ b/Focus/Iso.swift
@@ -82,7 +82,7 @@ extension IsoType {
 }
 
 /// Compose isomorphisms.
-public func • <Left : IsoType, Right: IsoType where
+public func • <Left : IsoType, Right : IsoType where
 	Left.Target == Right.Source,
 	Left.AltTarget == Right.AltSource>
 	(l : Left, r : Right) -> Iso<Left.Source, Left.AltSource, Right.Target, Right.AltTarget>

--- a/Focus/Lens.swift
+++ b/Focus/Lens.swift
@@ -58,7 +58,7 @@ public struct Lens<S, T, A, B> : LensType {
 	}
 }
 
-public protocol LensType: OpticFamilyType {
+public protocol LensType : OpticFamilyType {
 	/// Gets the Indexed Costate Comonad Coalgebroid underlying the receiver.
 	func run(_ : Source) -> IxStore<Target, AltTarget, AltSource>
 }
@@ -135,7 +135,7 @@ extension LensType {
 	}
 }
 
-public func • <Left : LensType, Right: LensType where
+public func • <Left : LensType, Right : LensType where
 	Left.Target == Right.Source,
 	Left.AltTarget == Right.AltSource>
 	(l : Left, r : Right) -> Lens<Left.Source, Left.AltSource, Right.Target, Right.AltTarget> {

--- a/Focus/Lens.swift
+++ b/Focus/Lens.swift
@@ -63,6 +63,15 @@ public protocol LensType: OpticFamilyType {
 	func run(_ : Source) -> IxStore<Target, AltTarget, AltSource>
 }
 
+extension Lens {
+	public init<Other : LensType where
+		S == Other.Source, A == Other.Target, T == Other.AltSource, B == Other.AltTarget>
+		(_ other : Other)
+	{
+		self.init(other.run)
+	}
+}
+
 extension LensType {
 	/// Runs the getter on a given structure.
 	public func get(v : Source) -> Target {

--- a/Focus/Prism.swift
+++ b/Focus/Prism.swift
@@ -35,7 +35,7 @@ public struct Prism<S, T, A, B> : PrismType {
 	}
 }
 
-public protocol PrismType: OpticFamilyType {
+public protocol PrismType : OpticFamilyType {
 	func tryGet(_ : Source) -> Target?
 	func inject(_ : AltTarget) -> AltSource
 }
@@ -76,7 +76,7 @@ extension PrismType {
 	}
 }
 
-public func • <Left : PrismType, Right: PrismType where
+public func • <Left : PrismType, Right : PrismType where
 	Left.Target == Right.Source,
 	Left.AltTarget == Right.AltSource>
 	(l : Left, r : Right) -> Prism<Left.Source, Left.AltSource, Right.Target, Right.AltTarget> {

--- a/Focus/Prism.swift
+++ b/Focus/Prism.swift
@@ -12,30 +12,32 @@
 /// - parameter T: The modified source of the Prism
 /// - parameter A: The possible target of the Prism
 /// - parameter B: The modified target the Prism
-public struct Prism<S, T, A, B> {
-	public let tryGet : S -> A?
-	public let inject : B -> T
+public struct Prism<S, T, A, B> : PrismType {
+	typealias Source = S
+	typealias Target = A
+	typealias AltSource = T
+	typealias AltTarget = B
 
-	public init(tryGet : S -> A?, inject : B -> T) {
-		self.tryGet = tryGet
-		self.inject = inject
+	private let _tryGet : S -> A?
+	private let _inject : B -> T
+
+	public init(tryGet f : S -> A?, inject g : B -> T) {
+		_tryGet = f
+		_inject = g
 	}
 
-	/// Composes a `Prism` with the receiver.
-	public func compose<I, J>(i2 : Prism<A, B, I, J>) -> Prism<S, T, I, J> {
-		return self • i2
+	public func tryGet(v : Source) -> Target? {
+		return _tryGet(v)
 	}
-	
-	/// Attempts to run a value of type `S` along both parts of the Prism.  If `.None` is
-	/// encountered along the getter returns `.None`, else returns `.Some` containing the final
-	/// value.
-	public func tryModify(s : S, _ f : A -> B) -> T? {
-		return tryGet(s).map(self.inject • f)
+
+	public func inject(x : AltTarget) -> AltSource {
+		return _inject(x)
 	}
 }
 
-public func • <S, T, I, J, A, B>(p1 : Prism<S, T, I, J>, p2 : Prism<I, J, A, B>) -> Prism<S, T, A, B> {
-	return Prism(tryGet: { p1.tryGet($0).flatMap(p2.tryGet) }, inject: p1.inject • p2.inject)
+public protocol PrismType: OpticFamilyType {
+	func tryGet(_ : Source) -> Target?
+	func inject(_ : AltTarget) -> AltSource
 }
 
 /// Provides a Prism for tweaking values inside `.Some`.
@@ -46,4 +48,28 @@ public func _Some<A, B>() -> Prism<A?, B?, A, B> {
 /// Provides a Prism for traversing `.None`.
 public func _None<A, B>() -> Prism<A?, B?, A, B> {
 	return Prism(tryGet: { _ in .None }, inject: { _ in .None })
+}
+
+extension PrismType {
+	/// Composes a `Prism` with the receiver.
+	public func compose<Other : PrismType where
+		Self.Target == Other.Source,
+		Self.AltTarget == Other.AltSource>
+		(other : Other) -> Prism<Source, AltSource, Other.Target, Other.AltTarget> {
+		return Prism(tryGet: { self.tryGet($0).flatMap(other.tryGet) }, inject: self.inject • other.inject)
+	}
+
+	/// Attempts to run a value of type `S` along both parts of the Prism.  If `.None` is
+	/// encountered along the getter returns `.None`, else returns `.Some` containing the final
+	/// value.
+	public func tryModify(s : Source, _ f : Target -> AltTarget) -> AltSource? {
+		return tryGet(s).map(self.inject • f)
+	}
+}
+
+public func • <Left : PrismType, Right: PrismType where
+	Left.Target == Right.Source,
+	Left.AltTarget == Right.AltSource>
+	(l : Left, r : Right) -> Prism<Left.Source, Left.AltSource, Right.Target, Right.AltTarget> {
+	return l.compose(r)
 }

--- a/Focus/Prism.swift
+++ b/Focus/Prism.swift
@@ -40,6 +40,15 @@ public protocol PrismType: OpticFamilyType {
 	func inject(_ : AltTarget) -> AltSource
 }
 
+extension Prism {
+	public init<Other : PrismType where
+		S == Other.Source, A == Other.Target, T == Other.AltSource, B == Other.AltTarget>
+		(_ other : Other)
+	{
+		self.init(tryGet: other.tryGet, inject: other.inject)
+	}
+}
+
 /// Provides a Prism for tweaking values inside `.Some`.
 public func _Some<A, B>() -> Prism<A?, B?, A, B> {
 	return Prism(tryGet: identity, inject: Optional<B>.Some)

--- a/Focus/Protocols.swift
+++ b/Focus/Protocols.swift
@@ -1,0 +1,16 @@
+//
+//  Protocols.swift
+//  Focus
+//
+//  Created by Alexander Ronald Altman on 7/13/15.
+//  Copyright © 2015 TypeLift. All rights reserved.
+//
+
+import Foundation
+
+public protocol OpticFamilyType {
+	typealias Source
+	typealias Target
+	typealias AltSource
+	typealias AltTarget
+}

--- a/Focus/Protocols.swift
+++ b/Focus/Protocols.swift
@@ -5,9 +5,6 @@
 //  Created by Alexander Ronald Altman on 7/13/15.
 //  Copyright © 2015 TypeLift. All rights reserved.
 //
-
-import Foundation
-
 public protocol OpticFamilyType {
 	typealias Source
 	typealias Target

--- a/Focus/Protocols.swift
+++ b/Focus/Protocols.swift
@@ -5,6 +5,12 @@
 //  Created by Alexander Ronald Altman on 7/13/15.
 //  Copyright © 2015 TypeLift. All rights reserved.
 //
+
+/// The shared supertype of all optics.
+///
+/// N.B.: Right now, this exists solely to standardize the four
+/// `typealias`es that the other `protocol`s all use, but, in future
+/// releases, `extension`s of it may provide some optic-generic operators.
 public protocol OpticFamilyType {
 	typealias Source
 	typealias Target

--- a/FocusTests/IsoSpec.swift
+++ b/FocusTests/IsoSpec.swift
@@ -26,5 +26,19 @@ class IsoSpec : XCTestCase {
 			let iso = Iso<Int, Int, UInt, UInt>(get: fs.getTo, inject: fs.getFrom)
 			return iso.modify(x, { $0 }) == x
 		}
+
+		property("compose is associative (get)") <- forAll { (x : Int, fs : IsoOf<Int, Int>, gs : IsoOf<Int, Int>) in
+			let iso1 = Iso<Int, Int, Int, Int>(get: fs.getTo, inject: fs.getFrom)
+			let iso2 = Iso<Int, Int, Int, Int>(get: gs.getTo, inject: gs.getFrom)
+			let isoC = iso1.compose(iso2)
+			return iso2.get(iso1.get(x)) == isoC.get(x)
+		}
+
+		property("compose is associative (inject)") <- forAll { (x : Int, fs : IsoOf<Int, Int>, gs : IsoOf<Int, Int>) in
+			let iso1 = Iso<Int, Int, Int, Int>(get: fs.getTo, inject: fs.getFrom)
+			let iso2 = Iso<Int, Int, Int, Int>(get: gs.getTo, inject: gs.getFrom)
+			let isoC = iso1.compose(iso2)
+			return iso1.inject(iso2.inject(x)) == isoC.inject(x)
+		}
 	}
 }


### PR DESCRIPTION
This pull request introduces the `IsoType`, `LensType`, `PrismType`, and `OpticFamilyType` `protocol`s, and moves a lot of functionality to `extension`s on them rather than methods on the underlying `struct`s.

This shouldn’t affect any current usages of the library, other than no longer requiring `asLens` or `asPrism` calls (thus, those functions have been removed).  However, it will allow for much easier expansion in the future, as well as greater fluidity of the interface when it comes to the “multiple inheritance” of various optic types.
