### PR TITLE
Update SwiftCheck dependency

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "typelift/Operadics" "v0.1.2"
-github "typelift/SwiftCheck" "4f74ca9d81faf822e10d81c9b22aa27478c64986"
+github "typelift/SwiftCheck" "c1883d08c9a41e8d5f375c83d387411e659c1521"


### PR DESCRIPTION
This is the only thing we need to do to make Focus play nicely with Xcode 7 beta 5.
