### PR TITLE
Use vars to enable terser lens declarations

### DIFF
--- a/FocusTests/UserExample.swift
+++ b/FocusTests/UserExample.swift
@@ -11,10 +11,10 @@ import Focus
 // A user example
 // an example of why we need SYB, Generics or macros
 public class User {
-	let name : String
-	let age : Int
-	let tweets : [String]
-	let attr : String
+	var name : String
+	var age : Int
+	var tweets : [String]
+	var attr : String
 	
 	public init(_ n : String, _ a : Int, _ t : [String], _ r : String) {
 		name = n
@@ -31,4 +31,24 @@ public class User {
 
 public func ==(lhs : User, rhs : User) -> Bool {
 	return lhs.name == rhs.name && lhs.age == rhs.age && lhs.tweets == rhs.tweets && lhs.attr == rhs.attr
+}
+
+protocol Focusable {
+}
+
+extension Focusable {
+	static func lens<T>(getter: Self -> T, _ setter: (inout Self, T) -> Void) -> Lens<Self, Self, T, T> {
+		return Lens(get: getter, set: { this, value in
+			var this = this
+			setter(&this, value)
+			return this
+		})
+	}
+}
+
+extension User : Focusable {
+	static let userName = User.lens({ $0.name }, { $0.name = $1 })
+	static let userAge = User.lens({ $0.age }, { $0.age = $1 })
+	static let userTweets = User.lens({ $0.tweets }, { $0.tweets = $1 })
+	static let userAttr = User.lens({ $0.attr }, { $0.attr = $1 })
 }

--- a/FocusTests/UserExample.swift
+++ b/FocusTests/UserExample.swift
@@ -34,10 +34,12 @@ public func ==(lhs : User, rhs : User) -> Bool {
 }
 
 protocol Focusable {
+	associatedtype Focal = Self
 }
 
 extension Focusable {
-	static func lens<T>(getter: Self -> T, _ setter: (inout Self, T) -> Void) -> Lens<Self, Self, T, T> {
+	/// Points the Focal, creatng a lens on the `var` property
+	static func point<T>(getter: Self -> T, _ setter: (inout Self, T) -> Void) -> Lens<Self, Self, T, T> {
 		return Lens(get: getter, set: { this, value in
 			var this = this
 			setter(&this, value)
@@ -47,8 +49,13 @@ extension Focusable {
 }
 
 extension User : Focusable {
-	static let userName = User.lens({ $0.name }, { $0.name = $1 })
-	static let userAge = User.lens({ $0.age }, { $0.age = $1 })
-	static let userTweets = User.lens({ $0.tweets }, { $0.tweets = $1 })
-	static let userAttr = User.lens({ $0.attr }, { $0.attr = $1 })
+	static let userName = Focal.point({ $0.name }, { $0.name = $1 })
+	static let userAge = Focal.point({ $0.age }, { $0.age = $1 })
+	static let userTweets = Focal.point({ $0.tweets }, { $0.tweets = $1 })
+	static let userAttr = Focal.point({ $0.attr }, { $0.attr = $1 })
+}
+
+extension Party : Focusable {
+	// if `host` were a `var`, we could also do this:
+	// static let partyHost = Focal.point({ $0.host }, { $0.host = $1 })
 }

--- a/FocusTests/UserExample.swift
+++ b/FocusTests/UserExample.swift
@@ -11,10 +11,10 @@ import Focus
 // A user example
 // an example of why we need SYB, Generics or macros
 public class User {
-	var name : String
-	var age : Int
-	var tweets : [String]
-	var attr : String
+	public internal(set) var name : String
+	public internal(set) var age : Int
+	public internal(set) var tweets : [String]
+	public internal(set) var attr : String
 	
 	public init(_ n : String, _ a : Int, _ t : [String], _ r : String) {
 		name = n


### PR DESCRIPTION
Is there any reason vars shouldn't be used in data model structs? The struct will still be immutable in the sense that there is no shared mutable state, and it would permit lenses to be expressed without having the call the struct's initializer for each individual lens.
